### PR TITLE
Fix usage of Helm global values

### DIFF
--- a/__fixtures__/basic/values.yaml
+++ b/__fixtures__/basic/values.yaml
@@ -17,7 +17,7 @@ ingress:
   # Used to create an Ingress record.
   hosts:
     - chart-example.local
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/__fixtures__/with-subchart/charts/child-chart/templates/deployment.yaml
+++ b/__fixtures__/with-subchart/charts/child-chart/templates/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    version: {{ default "none" .Values.global.version }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:

--- a/__fixtures__/with-subchart/charts/child-chart/tests/deployment_test.yaml
+++ b/__fixtures__/with-subchart/charts/child-chart/tests/deployment_test.yaml
@@ -7,6 +7,7 @@ tests:
       - ./values/image.yaml
     set:
       service.internalPort: 8080
+      global.version: v2.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -44,3 +45,6 @@ tests:
           count: 1
       - matchSnapshot:
           path: spec
+      - equal:
+          path: metadata.annotations.version
+          value: v2.0.0

--- a/__fixtures__/with-subchart/values.yaml
+++ b/__fixtures__/with-subchart/values.yaml
@@ -1,6 +1,8 @@
 # Default values for basic.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+  version: v1.0.0
 replicaCount: 1
 image:
   repository: nginx

--- a/__fixtures__/with-subchart/values.yaml
+++ b/__fixtures__/with-subchart/values.yaml
@@ -18,7 +18,7 @@ ingress:
   # Used to create an Ingress record.
   hosts:
     - chart-example.local
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/unittest/snapshot/cache_test.go
+++ b/unittest/snapshot/cache_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/vbehar/helm3-unittest/unittest/snapshot"
 	"github.com/stretchr/testify/assert"
+	. "github.com/vbehar/helm3-unittest/unittest/snapshot"
 )
 
 var lastTimeContent = `cached before:

--- a/unittest/snapshot/factory_test.go
+++ b/unittest/snapshot/factory_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/vbehar/helm3-unittest/unittest/snapshot"
 	"github.com/stretchr/testify/assert"
+	. "github.com/vbehar/helm3-unittest/unittest/snapshot"
 )
 
 func TestCreateSnapshotOfSuiteReturnCacheRight(t *testing.T) {

--- a/unittest/test_runner_test.go
+++ b/unittest/test_runner_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
-	. "github.com/vbehar/helm3-unittest/unittest"
 	"github.com/stretchr/testify/assert"
+	. "github.com/vbehar/helm3-unittest/unittest"
 )
 
 var sectionBeginPattern = regexp.MustCompile("( PASS | FAIL |\n*###|\n*Charts:|\n*Snapshot Summary:)")

--- a/unittest/utils.go
+++ b/unittest/utils.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	"helm.sh/helm/v3/pkg/chartutil"
 	"path/filepath"
 	"strings"
 )
@@ -16,11 +17,20 @@ func spliteChartRoutes(routePath string) []string {
 
 func scopeValuesWithRoutes(routes []string, values map[interface{}]interface{}) map[interface{}]interface{} {
 	if len(routes) > 1 {
+		v, hasGlobal := values[chartutil.GlobalKey]
+		if hasGlobal {
+			delete(values, chartutil.GlobalKey)
+		}
+		scopedValues := map[interface{}]interface{}{
+			routes[len(routes)-1]: values,
+		}
+		if hasGlobal {
+			scopedValues[chartutil.GlobalKey] = v
+		}
+
 		return scopeValuesWithRoutes(
 			routes[:len(routes)-1],
-			map[interface{}]interface{}{
-				routes[len(routes)-1]: values,
-			},
+			scopedValues,
 		)
 	}
 	return values

--- a/unittest/validators/common.go
+++ b/unittest/validators/common.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/vbehar/helm3-unittest/unittest/snapshot"
-	"github.com/pmezard/go-difflib/difflib"
 )
 
 // SnapshotComparer provide CompareToSnapshot utility to validator

--- a/unittest/validators/contains_validator_test.go
+++ b/unittest/validators/contains_validator_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
 
-	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/vbehar/helm3-unittest/unittest/common"
 )
 
 var docToTestContains = `

--- a/unittest/validators/equal_validator_test.go
+++ b/unittest/validators/equal_validator_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
 
-	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/vbehar/helm3-unittest/unittest/common"
 )
 
 var docToTestEqual = `

--- a/unittest/validators/has_document_validator_test.go
+++ b/unittest/validators/has_document_validator_test.go
@@ -3,9 +3,9 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHasDocumentsValidatorOk(t *testing.T) {

--- a/unittest/validators/is_apiversion_validator_test.go
+++ b/unittest/validators/is_apiversion_validator_test.go
@@ -3,9 +3,9 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIsAPiVersionValidatorWhenOk(t *testing.T) {

--- a/unittest/validators/is_empty_validator_test.go
+++ b/unittest/validators/is_empty_validator_test.go
@@ -3,9 +3,9 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
-	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/unittest/validators/is_kind_validator_test.go
+++ b/unittest/validators/is_kind_validator_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
 
-	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/vbehar/helm3-unittest/unittest/common"
 )
 
 func TestIsKindValidatorWhenOk(t *testing.T) {

--- a/unittest/validators/is_null_validator_test.go
+++ b/unittest/validators/is_null_validator_test.go
@@ -3,9 +3,9 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIsNullValidatorWhenOk(t *testing.T) {

--- a/unittest/validators/match_regex_validator_test.go
+++ b/unittest/validators/match_regex_validator_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
 
-	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/vbehar/helm3-unittest/unittest/common"
 )
 
 var docToTestMatchRegex = `

--- a/unittest/validators/snapshot_validator_test.go
+++ b/unittest/validators/snapshot_validator_test.go
@@ -3,11 +3,11 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	"github.com/vbehar/helm3-unittest/unittest/snapshot"
 	. "github.com/vbehar/helm3-unittest/unittest/validators"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type mockSnapshotComparer struct {

--- a/unittest/valueutils/valueutils_test.go
+++ b/unittest/valueutils/valueutils_test.go
@@ -3,9 +3,9 @@ package valueutils_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vbehar/helm3-unittest/unittest/common"
 	. "github.com/vbehar/helm3-unittest/unittest/valueutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetValueOfSetPath(t *testing.T) {


### PR DESCRIPTION
The implicit scoping of subcharts values breaks the usage of global values.
I modified it to make sure "global" sections is never scoped.
 
See the test added in `__fixtures__/with-subcharts` for an example.

The last two commits are unrelated to the issue.